### PR TITLE
macOS support: install discovery, main.js detection, ad-hoc re-signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ Headers: {"Alt-Svc":["h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"],"Cont
 ## 🌟 Возможности
 - Автоматический поиск установленного Antigravity в стандартных путях и реестре Windows.
 - Поддержка Linux: поиск по `/usr/share/antigravity`, определение версии через `dpkg`, `rpm` и `package.json`.
+- Поддержка macOS: поиск `.app`-бандла в `/Applications` и `~/Applications`, ad-hoc переподпись после изменения `main.js`.
 - Создание резервной копии `main.js.bak` перед изменениями.
 - Применение и откат патча через простое меню.
 - Поддержка путей `resources/app/out/main.js` и `resources/app/main.js`.
 - Цветной вывод и попытка автоматического повышения прав (UAC на Windows, предложение `sudo` на Linux).
 - Проверка минимальной версии Antigravity (>= `1.22.2`) перед применением патча.
-- Определение версии Antigravity через реестр Windows или пакетный менеджер на Linux.
+- Определение версии Antigravity через реестр Windows, пакетный менеджер на Linux или `package.json` на macOS.
 - Обнаружение уже применённого патча с предложением применить повторно.
 
 ## 🚀 Как использовать
@@ -98,9 +99,16 @@ python main.py "C:\\Program Files\\Antigravity\\resources\\app\\out\\main.js"
 # Linux
 python main.py /usr/share/antigravity
 python main.py /usr/share/antigravity/resources/app/out/main.js
+
+# macOS
+python3 main.py /Applications/Antigravity.app
+python3 main.py ~/Applications/Antigravity.app
+python3 main.py /Applications/Antigravity.app/Contents/Resources/app/out/main.js
 ```
 
 Если `main.js` находится рядом со скриптом, путь указывать не нужно — он будет найден автоматически.
+
+> **macOS:** если `Antigravity.app` лежит в `/Applications`, запись потребует `sudo` (скрипт сам предложит перезапуск). Для установки в `~/Applications` или пользовательскую директорию `sudo` не нужен. После успешного патча `.app` автоматически переподписывается ad-hoc подписью (`codesign --force --deep --sign -`) — без этого Electron с Hardened Runtime не запустится на macOS.
 
 ## ❓ Что именно меняется
 
@@ -133,12 +141,18 @@ python main.py /usr/share/antigravity/resources/app/out/main.js
      - `%PROGRAMFILES(X86)%\Antigravity`
    - **Linux:**
      - `/usr/share/antigravity`
+   - **macOS:**
+     - `/Applications/Antigravity.app/Contents/Resources/app`
+     - `~/Applications/Antigravity.app/Contents/Resources/app`
 4. Реестр Windows (ключ `{AA73B3E3-C6C8-45C8-B1DC-4AE56C751432}_is1` в `HKCU` и `HKLM`: `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\`).
 
 Внутри найденной директории проверяются пути:
 - `resources/app/out/main.js`
 - `resources/app/main.js`
+- `out/main.js` (macOS)
 - `main.js` (если путь указан напрямую)
+
+На macOS скрипт также принимает путь к `.app`-бандлу напрямую — `Contents/Resources/app/out/main.js` ресолвится автоматически.
 
 ## 🔎 Определение версии Antigravity
 
@@ -148,6 +162,7 @@ python main.py /usr/share/antigravity/resources/app/out/main.js
 | **Linux (deb)** | `dpkg-query -W antigravity` |
 | **Linux (rpm)** | `rpm -q --queryformat %{VERSION} antigravity` |
 | **Linux (portable/snap/flatpak)** | `package.json` рядом с `main.js` |
+| **macOS** | `package.json` в `Antigravity.app/Contents/Resources/app/` |
 
 Если версия не определена, патчер предлагает продолжить без проверки. Если версия ниже `1.22.2` — предупреждает и также предлагает выбор.
 
@@ -163,12 +178,42 @@ python main.py /usr/share/antigravity/resources/app/out/main.js
 
 - **Windows**: автоматический UAC-запрос через `ShellExecuteW` с параметром `runas`. Корректно обрабатывает пути с пробелами.
 - **Linux**: если скрипт запущен не от root, предлагает перезапуститься через `sudo` (`os.execvp`). При отказе продолжает с предупреждением о возможных ошибках записи.
+- **macOS**: использует ту же posix-ветку — `sudo` предлагается, если запущено без root. Для `~/Applications/Antigravity.app` на `sudo` можно ответить «n» (директория уже доступна на запись), для `/Applications/Antigravity.app` — согласиться.
+
+## 🍎 Особенности macOS
+
+### Переподпись `.app` после патча
+
+Любое изменение файла внутри подписанного `.app`-бандла нарушает code signature. Electron-приложения с включённым Hardened Runtime (Antigravity — одно из них) после этого **не запускаются** на macOS — до того, как Gatekeeper вообще покажет пользователю диалог.
+
+Чтобы `.app` продолжал работать, скрипт после `do_patch` и `do_restore` автоматически выполняет:
+
+```bash
+codesign --force --deep --sign - /path/to/Antigravity.app
+xattr -dr com.apple.quarantine /path/to/Antigravity.app
+```
+
+`--sign -` — ad-hoc подпись (без Developer ID). Этого достаточно для локального запуска приложения. Notarization не требуется.
+
+Требуется установленный `codesign` — он идёт в составе **Xcode Command Line Tools**:
+```bash
+xcode-select --install
+```
+
+### Если приложение не запускается после патча
+
+1. Убедись, что `codesign` доступен: `which codesign`.
+2. Проверь, что `.app` был переподписан: `codesign -dv /Applications/Antigravity.app 2>&1 | grep Authority` — должен быть `Signature=adhoc`.
+3. Если macOS всё равно блокирует: `Системные настройки → Конфиденциальность и безопасность` — внизу будет кнопка «Открыть всё равно».
 
 ## ⚙️ Требования
 
 - **Python** 3.x
 - **Зависимости**: `packaging` (для сравнения версий)
-- **ОС**: Windows (полная поддержка автопоиска через реестр и UAC) или Linux (автопоиск в `/usr/share/antigravity`, определение версии через `dpkg`/`rpm`/`package.json`, sudo-повышение). На macOS работает при ручном указании пути.
+- **ОС**:
+  - **Windows** — полная поддержка автопоиска через реестр и UAC.
+  - **Linux** — автопоиск в `/usr/share/antigravity`, определение версии через `dpkg`/`rpm`/`package.json`, sudo-повышение.
+  - **macOS** — автопоиск в `/Applications/Antigravity.app` и `~/Applications/Antigravity.app`, определение версии через `package.json`, ad-hoc переподпись через `codesign` (Xcode Command Line Tools).
 - **Минимальная версия Antigravity**: `1.22.2`
 
 ## 🛠️ Сборка
@@ -176,7 +221,8 @@ python main.py /usr/share/antigravity/resources/app/out/main.js
 ```bash
 pip install -r requirements.txt
 Windows: pyinstaller --onefile --uac-admin --icon=icon.ico --name="Open_AG_Patcher_Windows" main.py
-Linux: pyinstaller --onefile --icon=icon.ico --name="Open_AG_Patcher_Linux" main.py
+Linux:   pyinstaller --onefile --icon=icon.ico --name="Open_AG_Patcher_Linux" main.py
+macOS:   pyinstaller --onefile --name="Open_AG_Patcher_macOS" main.py
 ```
 
 ## Структура проекта

--- a/main.py
+++ b/main.py
@@ -154,7 +154,15 @@ def run_as_admin():
 def find_install_root():
     candidates = []
 
-    if os.name == "posix":
+    if sys.platform == "darwin":
+        # На macOS приложение — .app-бандл, main.js лежит внутри Contents/Resources/app
+        mac_candidates = [
+            "/Applications/Antigravity.app",
+            os.path.expanduser("~/Applications/Antigravity.app"),
+        ]
+        for app in mac_candidates:
+            candidates.append(os.path.join(app, "Contents", "Resources", "app"))
+    elif os.name == "posix":
         candidates.append("/usr/share/antigravity")
 
     if os.name == "nt":
@@ -185,6 +193,8 @@ def find_install_root():
         for sub in [
             os.path.join("resources", "app", "out", "main.js"),
             os.path.join("resources", "app", "main.js"),
+            os.path.join("out", "main.js"),
+            "main.js",
         ]:
             if os.path.exists(os.path.join(path, sub)):
                 return path
@@ -192,9 +202,14 @@ def find_install_root():
 
 
 def find_main_js(root):
+    # macOS: пользователь может передать путь к .app-бандлу напрямую
+    if sys.platform == "darwin" and root.endswith(".app") and os.path.isdir(root):
+        root = os.path.join(root, "Contents", "Resources", "app")
+
     for sub in [
         os.path.join("resources", "app", "out", "main.js"),
         os.path.join("resources", "app", "main.js"),
+        os.path.join("out", "main.js"),
         "main.js",
     ]:
         p = os.path.join(root, sub)

--- a/main.py
+++ b/main.py
@@ -339,6 +339,62 @@ def file_size(path):
         return 0
 
 
+def find_app_bundle(path):
+    """Поднимается вверх от path до первой директории, оканчивающейся на .app.
+
+    Используется только на macOS, чтобы определить корень .app-бандла
+    для переподписи после модификации main.js.
+    """
+    p = os.path.abspath(path)
+    while p and p != os.path.dirname(p):
+        if p.endswith(".app"):
+            return p
+        p = os.path.dirname(p)
+    return ""
+
+
+def resign_macos_bundle(main_js_path):
+    """Переподписывает .app ad-hoc подписью после изменения main.js.
+
+    На macOS любая модификация файла внутри подписанного .app-бандла
+    нарушает code signature. Electron-приложения с Hardened Runtime
+    после этого падают при запуске. codesign --force --sign - кладёт
+    ad-hoc подпись (без Developer ID), чего достаточно для локального
+    запуска. Дополнительно снимается атрибут com.apple.quarantine,
+    чтобы Gatekeeper не показывал предупреждение.
+    """
+    if sys.platform != "darwin":
+        return
+
+    app_path = find_app_bundle(main_js_path)
+    if not app_path:
+        # main.js лежит не внутри .app (например, portable-копия) — пропускаем
+        return
+
+    print(f"  [*] Re-signing {os.path.basename(app_path)} (ad-hoc)...")
+    try:
+        subprocess.run(
+            ["codesign", "--force", "--deep", "--sign", "-", app_path],
+            check=True, capture_output=True, text=True,
+        )
+        print(color("  [+] Ad-hoc signature applied", COLOR_GREEN))
+    except FileNotFoundError:
+        print(color("  [!] codesign not found — install Xcode Command Line Tools", COLOR_YELLOW))
+        return
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        print(color(f"  [!] codesign failed: {stderr}", COLOR_YELLOW))
+        return
+
+    try:
+        subprocess.run(
+            ["xattr", "-dr", "com.apple.quarantine", app_path],
+            check=False, capture_output=True,
+        )
+    except FileNotFoundError:
+        pass
+
+
 def format_bytes(size_bytes):
     if size_bytes >= 1024 * 1024:
         return f"{size_bytes / 1024 / 1024:.1f} MB"
@@ -655,6 +711,7 @@ def do_patch(main_js_path, show_search_line=False):
         return
 
     hash_after = file_hash(main_js_path)
+    resign_macos_bundle(main_js_path)
     print(f"  [+] Patches: {applied}/{len(results)} applied")
     if hash_before and hash_after:
         print(f"  [+] Before:  {hash_before[:8]}...{hash_before[56:]}")
@@ -729,6 +786,7 @@ def do_restore(main_js_path, show_search_line=False):
         return
 
     hash_after = file_hash(main_js_path)
+    resign_macos_bundle(main_js_path)
 
     # Удаляем мета-файлы бэкапа — после восстановления они уже неактуальны
     for ext in (".version", ".sha256"):


### PR DESCRIPTION
## Summary

Adds macOS support to the patcher. Existing Windows/Linux behaviour is untouched — all new code paths are gated behind `sys.platform == \"darwin\"`.

## Changes

- `find_install_root()` now checks `/Applications/Antigravity.app` and `~/Applications/Antigravity.app`, resolving the inner `Contents/Resources/app` as the root (plus `out/main.js` as a new subpath).
- `find_main_js()` accepts a path to the `.app` bundle directly and resolves `main.js` inside it.
- New helpers `find_app_bundle()` and `resign_macos_bundle()`. The latter runs `codesign --force --deep --sign -` on Darwin after a successful write in `do_patch()` and `do_restore()`, and also clears `com.apple.quarantine`. On non-Darwin platforms both helpers are no-ops.

## Why re-signing is needed on macOS

Any modification of a file inside a signed `.app` bundle invalidates the bundle's code signature. Electron apps with Hardened Runtime (Antigravity is one) fail to launch on macOS after that — before Gatekeeper even prompts the user. `codesign --force --sign -` puts an ad-hoc signature on the bundle, which is enough for local execution. No Developer ID or notarization required.

## Test plan

Tested on Antigravity 1.107.0, macOS 14+ (Darwin 25), Python 3.12:
- `.app` bundle in a user-writable directory — no sudo required.
- `main.js` is located automatically both via `find_install_root()` and via passing the `.app` path as an argument.
- Patching succeeds, the bundle re-signs cleanly, Antigravity launches afterwards.
- Restore from `.bak` + re-sign also works.

Linux and Windows paths were not re-tested on hardware, but every new code branch is guarded — existing logic for `os.name == \"nt\"` and non-Darwin POSIX is unchanged.

## Breaking changes

None.

## Notes / out of scope

Version detection on macOS falls back to `package.json` via the existing POSIX branch — works on 1.107.0. No changes to `apply_patches_minimal()` itself are included here; any version-specific patch tweaks belong in a separate PR.